### PR TITLE
Merge fix_request_8_days to master

### DIFF
--- a/src/main/java/aspedrosa/weatherforecast/services/ApixuAPIService.java
+++ b/src/main/java/aspedrosa/weatherforecast/services/ApixuAPIService.java
@@ -39,7 +39,7 @@ public class ApixuAPIService extends ForecastAPIService {
      */
     @Override
     public int MAX_DAYS_COUNT() {
-        return 10;
+        return 7;
     }
 
     /**

--- a/src/main/java/aspedrosa/weatherforecast/services/DarkSkyAPIService.java
+++ b/src/main/java/aspedrosa/weatherforecast/services/DarkSkyAPIService.java
@@ -92,7 +92,7 @@ public class DarkSkyAPIService extends ForecastAPIService {
         for (int i = 0; i < MAX_DAYS_COUNT(); i++) {
             JSONObject json_day_forecast = json_forecast.getJSONObject(i);
             DailyForecast day_forecast = new DailyForecast();
-            day_forecast.set_icon(icons.get(json_current.getString("icon")));
+            day_forecast.set_icon(icons.get(json_day_forecast.getString("icon")));
             day_forecast.set_humidity(100 * json_day_forecast.getDouble("humidity"));
             day_forecast.set_max_temperature(json_day_forecast.getDouble("temperatureMax"));
             day_forecast.set_min_temperature(json_day_forecast.getDouble("temperatureMin"));

--- a/src/test/java/aspedrosa/weatherforecast/services/ForecastServiceIT.java
+++ b/src/test/java/aspedrosa/weatherforecast/services/ForecastServiceIT.java
@@ -167,7 +167,7 @@ public class ForecastServiceIT {
 
         CurrentWeather current_weather = forecast.getCurrent_weather();
         assertEquals(87, current_weather.get_humidity(), 0);
-        assertNull(current_weather.get_icon());
+        assertEquals("images/Cloud-Sun.svg", current_weather.get_icon());
         assertEquals(101716, current_weather.get_pressure(), 0);
         assertEquals("Partly Cloudy", current_weather.get_summary());
         assertEquals(1, current_weather.get_uv(), 0);
@@ -179,7 +179,7 @@ public class ForecastServiceIT {
         DailyForecast daily_forecast = daily_forecasts.get(0);
         assertEquals("Foggy in the morning.", daily_forecast.get_summary());
         assertEquals(91, daily_forecast.get_humidity(), 0);
-        assertNull(daily_forecast.get_icon());
+        assertEquals("images/Cloud-Fog.svg", daily_forecast.get_icon());
         assertEquals(17.02, daily_forecast.get_max_temperature(), 0);
         assertEquals(11.25, daily_forecast.get_min_temperature(), 0);
         assertEquals(5, daily_forecast.get_uv(), 0);

--- a/src/test/java/aspedrosa/weatherforecast/services/ForecastServiceTest.java
+++ b/src/test/java/aspedrosa/weatherforecast/services/ForecastServiceTest.java
@@ -65,10 +65,59 @@ public class ForecastServiceTest {
     }
 
     /**
+     * Whenever the clients asks for a number of days that
+     *  the api can give, then it should call the external api
+     *  that offers the most number of days of forecast data
+     * On this specific test we are considering that the primary
+     *  external api can offer more days, so only that one
+     *  should be called
+     */
+    @Test
+    public void use_primary_when_offers_more_days() {
+        Mockito.when(primary_api.MAX_DAYS_COUNT()).thenReturn(8);
+        Mockito.when(backup_api.MAX_DAYS_COUNT()).thenReturn(7);
+
+        Mockito.when(daily_cache.get_cached_data(coords)).thenReturn(null);
+        Mockito.when(primary_api.forecast(LATITUDE, LONGITUDE)).thenReturn(forecast);
+
+        forecast_service.forecast(LATITUDE, LONGITUDE, 10);
+
+        Mockito.verify(primary_api, Mockito.times(1)).forecast(LATITUDE, LONGITUDE);
+        Mockito.verify(backup_api, Mockito.times(0)).forecast(LATITUDE, LONGITUDE);
+        Mockito.verify(daily_cache, Mockito.times(1)).get_cached_data(coords);
+    }
+
+    /**
+     * Whenever the clients asks for a number of days that
+     *  the api can give, then it should call the external api
+     *  that offers the most number of days of forecast data
+     * On this specific test we are considering that the backup
+     *  external api can offer more days, so only that one
+     *  should be called
+     */
+    @Test
+    public void use_backup_when_offers_more_days() {
+        Mockito.when(primary_api.MAX_DAYS_COUNT()).thenReturn(7);
+        Mockito.when(backup_api.MAX_DAYS_COUNT()).thenReturn(8);
+
+        Mockito.when(daily_cache.get_cached_data(coords)).thenReturn(null);
+        Mockito.when(backup_api.forecast(LATITUDE, LONGITUDE)).thenReturn(forecast);
+
+        forecast_service.forecast(LATITUDE, LONGITUDE, 10);
+
+        Mockito.verify(primary_api, Mockito.times(0)).forecast(LATITUDE, LONGITUDE);
+        Mockito.verify(backup_api, Mockito.times(1)).forecast(LATITUDE, LONGITUDE);
+        Mockito.verify(daily_cache, Mockito.times(1)).get_cached_data(coords);
+    }
+
+    /**
      * If the primary api fails, use the backup one
      */
     @Test
     public void use_backup() {
+        Mockito.when(primary_api.MAX_DAYS_COUNT()).thenReturn(7);
+        Mockito.when(backup_api.MAX_DAYS_COUNT()).thenReturn(8);
+
         Mockito.when(primary_api.forecast(LATITUDE, LONGITUDE)).thenThrow(RestClientException.class);
         Mockito.when(daily_cache.get_cached_data(coords)).thenReturn(null);
         Mockito.when(backup_api.forecast(LATITUDE, LONGITUDE)).thenReturn(forecast);
@@ -85,6 +134,9 @@ public class ForecastServiceTest {
      */
     @Test
     public void dont_use_backup() {
+        Mockito.when(primary_api.MAX_DAYS_COUNT()).thenReturn(7);
+        Mockito.when(backup_api.MAX_DAYS_COUNT()).thenReturn(8);
+
         Mockito.when(daily_cache.get_cached_data(coords)).thenReturn(null);
         Mockito.when(primary_api.forecast(LATITUDE, LONGITUDE)).thenReturn(forecast);
 
@@ -102,6 +154,9 @@ public class ForecastServiceTest {
      */
     @Test
     public void cache_usage() {
+        Mockito.when(primary_api.MAX_DAYS_COUNT()).thenReturn(7);
+        Mockito.when(backup_api.MAX_DAYS_COUNT()).thenReturn(8);
+
         Mockito.when(primary_api.forecast(LATITUDE, LONGITUDE)).thenReturn(forecast);
         Mockito.when(daily_cache.get_cached_data(coords))
             .thenReturn(null)
@@ -135,6 +190,9 @@ public class ForecastServiceTest {
      */
     @Test
     public void cache_not_enough() {
+        Mockito.when(primary_api.MAX_DAYS_COUNT()).thenReturn(7);
+        Mockito.when(backup_api.MAX_DAYS_COUNT()).thenReturn(8);
+
         List<DailyForecast> forecasts_longer = new ArrayList<>();
         for (int i = 0; i < 4; i++)
             forecasts_longer.add(new DailyForecast());
@@ -173,6 +231,9 @@ public class ForecastServiceTest {
      */
     @Test
     public void only_current_not_cached() {
+        Mockito.when(primary_api.MAX_DAYS_COUNT()).thenReturn(7);
+        Mockito.when(backup_api.MAX_DAYS_COUNT()).thenReturn(8);
+
         Mockito.when(primary_api.forecast(LATITUDE, LONGITUDE))
             .thenReturn(forecast)
             .thenReturn(forecast);


### PR DESCRIPTION
Server is smarter on choosing the external api accordingly
to the number of days that those can offer and the number
of days that the client requests